### PR TITLE
Oauth2 client credentials flow

### DIFF
--- a/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
+++ b/pulsar-client/src/main/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlow.java
@@ -18,8 +18,8 @@
  */
 package org.apache.pulsar.client.impl.auth.oauth2;
 
+import com.google.common.annotations.VisibleForTesting;
 import java.io.IOException;
-import java.io.InputStream;
 import java.io.InputStreamReader;
 import java.io.Reader;
 import java.net.URISyntaxException;
@@ -36,6 +36,7 @@ import org.apache.pulsar.client.impl.auth.oauth2.protocol.ClientCredentialsExcha
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenClient;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenExchangeException;
 import org.apache.pulsar.client.impl.auth.oauth2.protocol.TokenResult;
+
 
 /**
  * Implementation of OAuth 2.0 Client Credentials flow.
@@ -137,19 +138,18 @@ class ClientCredentialsFlow extends FlowBase {
      * @return
      * @throws IOException
      */
-    private static KeyFile loadPrivateKey(String privateKeyURL) throws IOException {
+    @VisibleForTesting
+    static KeyFile loadPrivateKey(String privateKeyURL) throws IOException {
         try {
             URLConnection urlConnection = new org.apache.pulsar.client.api.url.URL(privateKeyURL).openConnection();
             try {
                 String protocol = urlConnection.getURL().getProtocol();
-                String contentType = urlConnection.getContentType();
-                if ("data".equals(protocol) && !"application/json".equals(contentType)) {
+                if ("data".equals(protocol) && !"application/json".equals(urlConnection.getContentType())) {
                     throw new IllegalArgumentException(
                             "Unsupported media type or encoding format: " + urlConnection.getContentType());
                 }
                 KeyFile privateKey;
-                try (Reader r = new InputStreamReader((InputStream) urlConnection.getContent(),
-                        StandardCharsets.UTF_8)) {
+                try (Reader r = new InputStreamReader(urlConnection.getInputStream(), StandardCharsets.UTF_8)) {
                     privateKey = KeyFile.fromJson(r);
                 }
                 return privateKey;

--- a/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlowTest.java
+++ b/pulsar-client/src/test/java/org/apache/pulsar/client/impl/auth/oauth2/ClientCredentialsFlowTest.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *   http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing,
+ * software distributed under the License is distributed on an
+ * "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+ * KIND, either express or implied.  See the License for the
+ * specific language governing permissions and limitations
+ * under the License.
+ */
+package org.apache.pulsar.client.impl.auth.oauth2;
+
+import org.testng.annotations.Test;
+
+import java.io.IOException;
+import java.io.InputStream;
+import java.net.URL;
+import java.net.URLConnection;
+import java.net.URLStreamHandler;
+import java.net.URLStreamHandlerFactory;
+
+import static org.testng.Assert.assertEquals;
+
+public class ClientCredentialsFlowTest {
+
+    private static void testLoadPrivateKeyFile(String keyFileUrl) {
+        try {
+            KeyFile keyFile = ClientCredentialsFlow.loadPrivateKey(keyFileUrl);
+            assertEquals(keyFile.getType(), "type");
+            assertEquals(keyFile.getClientId(), "client-id");
+            assertEquals(keyFile.getClientSecret(), "client-secret");
+            assertEquals(keyFile.getClientEmail(), "client-email");
+            assertEquals(keyFile.getIssuerUrl(), "https://issuer-url/");
+        } catch (IOException e) {
+            throw new RuntimeException(e);
+        }
+    }
+
+    @Test
+    public void testLoadPrivateKeyFromResourceUrl() {
+        testLoadPrivateKeyFile(ClientCredentialsFlowTest.class.getResource("/oauth2_key.json").toString());
+    }
+
+    @Test
+    public void testLoadPrivateKeyFromUrlHandlerUrl() {
+        ClasspathURLStreamHandler.register();
+        testLoadPrivateKeyFile("resource:oauth2_key.json");
+    }
+
+    @Test
+    public void testLoadPrivateKeyFromDataUrl() {
+        testLoadPrivateKeyFile("data:application/json;base64,ewogICJ0eXBlIjogInR5cGUiLAogICJjbGllbnRfaWQiOiAiY2xpZW50LWlkIiwKICAiY2xpZW50X3NlY3JldCI6ICJjbGllbnQtc2VjcmV0IiwKICAiY2xpZW50X2VtYWlsIjogImNsaWVudC1lbWFpbCIsCiAgImlzc3Vlcl91cmwiOiAiaHR0cHM6Ly9pc3N1ZXItdXJsLyIKfQ==");
+    }
+
+    public static class ClasspathURLStreamHandler implements URLStreamHandlerFactory {
+        private static final URLStreamHandlerFactory INSTANCE = new ClasspathURLStreamHandler();
+
+        public ClasspathURLStreamHandler() {
+        }
+
+        public static void register() {
+            URL.setURLStreamHandlerFactory(INSTANCE);
+        }
+
+        public URLStreamHandler createURLStreamHandler(String protocol) {
+            return "resource".equals(protocol) ? new URLStreamHandler() {
+                protected URLConnection openConnection(URL u) throws IOException {
+                    String path = u.getPath();
+                    ClassLoader classLoader = Thread.currentThread().getContextClassLoader();
+                    URL resource = classLoader == null ? null : classLoader.getResource(path);
+                    if (resource == null) {
+                        resource = ClassLoader.getSystemClassLoader().getResource(path);
+                    }
+
+                    return resource != null ? new NoContentTypeResourceUrlConnection(resource) : null;
+                }
+            } : null;
+        }
+
+        static class NoContentTypeResourceUrlConnection extends URLConnection {
+
+            public NoContentTypeResourceUrlConnection(URL url) {
+                super(url);
+                this.url = url;
+            }
+
+            @Override
+            public void connect() throws IOException {
+
+            }
+
+            @Override
+            public String getContentType() {
+                return null;
+            }
+
+            @Override
+            public String getContentEncoding() {
+                return "identity";
+            }
+
+            @Override
+            public InputStream getInputStream() throws IOException {
+                return url.openStream();
+            }
+        }
+
+    }
+
+}

--- a/pulsar-client/src/test/resources/oauth2_key.json
+++ b/pulsar-client/src/test/resources/oauth2_key.json
@@ -1,0 +1,7 @@
+{
+  "type": "type",
+  "client_id": "client-id",
+  "client_secret": "client-secret",
+  "client_email": "client-email",
+  "issuer_url": "https://issuer-url/"
+}


### PR DESCRIPTION
<!--
### Contribution Checklist
  
  - PR title format should be *[type][component] summary*. For details, see *[Guideline - Pulsar PR Naming Convention](https://pulsar.apache.org/contribute/develop-semantic-title/)*. 

  - Fill out the template below to describe the changes contributed by the pull request. That will give reviewers the context they need to do the review.
  
  - Each pull request should address only one issue, not mix up code from multiple issues.
  
  - Each commit in the pull request has a meaningful commit message

  - Once all items of the checklist are addressed, remove the above text and this checklist, leaving only the filled out template below.
-->

<!-- Either this PR fixes an issue, -->

Fixes #xyz

<!-- or this PR is one task of an issue -->

Main Issue: #xyz

<!-- If the PR belongs to a PIP, please add the PIP link here -->

PIP: #xyz 

<!-- Details of when a PIP is required and how the PIP process work, please see: https://github.com/apache/pulsar/blob/master/pip/README.md -->

### Motivation

<!-- Explain here the context, and why you're making that change. What is the problem you're trying to solve. -->
Private key loading during Oauth2 client credentials flow initialization requires the passed URL to provide content-type, even when the URL scheme is not `data`. 
Secondly, it also requires the content handler resolution even though InputStream is always used to parse the file content.

### Modifications

<!-- Describe the modifications you've done. -->
In `ClientCredentialsFlow.java`, 
- URL content type is only required if the scheme is `data`
- URLConnection getInputStream is used to get the content
- loadPrivateKey visibility increased for testing

### Verifying this change

- [ ] Make sure that the change passes the CI checks.
- [x] Added `ClientCredentialsFlowTest` to verify loading private 

*(Please pick either of the following options)*

This change is a trivial rework / code cleanup without any test coverage.

*(or)*

This change is already covered by existing tests, such as *(please describe tests)*.

*(or)*

This change added tests and can be verified as follows:

*(example:)*
  - *Added integration tests for end-to-end deployment with large payloads (10MB)*
  - *Extended integration test for recovery after broker failure*

### Does this pull request potentially affect one of the following parts:

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

*If the box was checked, please highlight the changes*

- [ ] Dependencies (add or upgrade a dependency)
- [ ] The public API
- [ ] The schema
- [ ] The default values of configurations
- [ ] The threading model
- [ ] The binary protocol
- [ ] The REST endpoints
- [ ] The admin CLI options
- [ ] The metrics
- [ ] Anything that affects deployment

### Documentation

<!-- DO NOT REMOVE THIS SECTION. CHECK THE PROPER BOX ONLY. -->

- [ ] `doc` <!-- Your PR contains doc changes. -->
- [ ] `doc-required` <!-- Your PR changes impact docs and you will update later -->
- [x] `doc-not-needed` <!-- Your PR changes do not impact docs -->
- [ ] `doc-complete` <!-- Docs have been already added -->

### Matching PR in forked repository

PR in forked repository: <!-- ENTER URL HERE -->

<!--
After opening this PR, the build in apache/pulsar will fail and instructions will
be provided for opening a PR in the PR author's forked repository.

apache/pulsar pull requests should be first tested in your own fork since the 
apache/pulsar CI based on GitHub Actions has constrained resources and quota.
GitHub Actions provides separate quota for pull requests that are executed in 
a forked repository.

The tests will be run in the forked repository until all PR review comments have
been handled, the tests pass and the PR is approved by a reviewer.
-->
